### PR TITLE
Adding missing -f in remove_os_generic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,15 +11,9 @@ from setuptools import setup
 # import DistUtilsExtra.command.clean_i18n
 
 # to update i18n .mo files (and merge .pot file into .po files) run on Linux:
-# ,,python setup.py build_i18n -m''
+# python setup.py build_i18n -m''
 
-for line in open('src/update-station').readlines():
-    if line.startswith('__VERSION__'):
-        exec(line.strip())
-        break
-# Silence flake8, __VERSION__ is properly assigned below
-else:
-    __VERSION__ = '5.1'
+__VERSION__ = '5.4'
 
 PROGRAM_VERSION = __VERSION__
 prefix = sys.prefix
@@ -28,14 +22,14 @@ prefix = sys.prefix
 os.system("sh compile_translations.sh")
 
 
-def datafilelist(installbase, sourcebase):
-    datafileList = []
-    for root, subFolders, files in os.walk(sourcebase):
-        fileList = []
+def data_file_list(install_base, source_base):
+    data = []
+    for root, subFolders, files in os.walk(source_base):
+        file_list = []
         for f in files:
-            fileList.append(os.path.join(root, f))
-        datafileList.append((root.replace(sourcebase, installbase), fileList))
-    return datafileList
+            file_list.append(os.path.join(root, f))
+        data.append((root.replace(source_base, install_base), file_list))
+    return data
 
 
 data_files = [
@@ -43,11 +37,10 @@ data_files = [
     (f'{prefix}/share/applications', ['src/update-manager.desktop']),
     (f'{prefix}/lib/update-station', ['src/need_reboot.json']),
     (f'{prefix}/etc/sudoers.d', ['src/sudoers.d/update-station']),
-    (f'{prefix}/share/locale/ru/LC_MESSAGES', ['src/locale/ru/update-station.mo']),
-
+    (f'{prefix}/share/locale/ru/LC_MESSAGES', ['src/locale/ru/update-station.mo'])
 ]
 
-data_files.extend(datafilelist(f'{prefix}/share/locale', 'build/mo'))
+data_files.extend(data_file_list(f'{prefix}/share/locale', 'build/mo'))
 
 setup(
     name="update-station",

--- a/src/update-station
+++ b/src/update-station
@@ -44,8 +44,6 @@ _ = gettext.gettext
 
 lib_path: str = f'{sys.prefix}/lib/update-station'
 
-__VERSION__ = '5.1'
-
 username = os.environ.get('SUDO_USER') if 'SUDO_USER' in os.environ else getpass.getuser()
 home = os.path.expanduser('~')
 

--- a/src/updateHandler.py
+++ b/src/updateHandler.py
@@ -326,7 +326,7 @@ def remove_os_generic(mount_point: str) -> CompletedProcess:
     This function is used to remove all os generic packages.
     :param mount_point: The mount point of the basepkg-test.
     """
-    return run_command(f'pkg-static -r {mount_point} delete -y -g "os-generic*"')
+    return run_command(f'pkg-static -r {mount_point} delete -yf -g "os-generic*"')
 
 
 def install_ghostbsd_pkgbase(mount_point: str) -> CompletedProcess:


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes a missing flag in the remove_os_generic function, updates the version number, and refactors a function for better readability and structure.

- **Bug Fixes**:
    - Fixed the command in remove_os_generic to include the missing -f flag for forced deletion.
- **Enhancements**:
    - Updated the version number from 5.1 to 5.4.
    - Refactored the datafilelist function to data_file_list with improved variable naming and structure.

<!-- Generated by sourcery-ai[bot]: end summary -->