### PR TITLE
Fixed get_default_repo_url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+# editor
+.idea
+.vscode

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from setuptools import setup
 # to update i18n .mo files (and merge .pot file into .po files) run on Linux:
 # python setup.py build_i18n -m''
 
-__VERSION__ = '5.4'
+__VERSION__ = '5.5'
 
 PROGRAM_VERSION = __VERSION__
 prefix = sys.prefix
@@ -45,6 +45,7 @@ data_files.extend(data_file_list(f'{prefix}/share/locale', 'build/mo'))
 setup(
     name="update-station",
     version=PROGRAM_VERSION,
+    #use_scm_version=True,
     description="Update Manager For GhostBSD/FreeBSD",
     license='BSD',
     author='Eric Turgeon',

--- a/src/updateHandler.py
+++ b/src/updateHandler.py
@@ -47,7 +47,7 @@ def get_default_repo_url() -> str:
     :return: The default pkg repository url.
     """
     raw_url = Popen(
-        'pkg -vv | grep -B 1 "enabled.*yes" | grep url',
+        'pkg -vv | grep -B 1 "enabled.*yes" | grep url | grep latest',
         shell=True,
         stdout=PIPE,
         close_fds=True,


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the get_default_repo_url function to correctly filter for the latest repository URL and update the version number in setup.py from 5.4 to 5.5.

Bug Fixes:
- Fix the get_default_repo_url function to correctly filter for the latest repository URL.

Enhancements:
- Update the version number in setup.py from 5.4 to 5.5.

<!-- Generated by sourcery-ai[bot]: end summary -->