### PR TITLE
Fixed repo_online url

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from setuptools import setup
 # to update i18n .mo files (and merge .pot file into .po files) run on Linux:
 # python setup.py build_i18n -m''
 
-__VERSION__ = '5.6'
+__VERSION__ = '5.7'
 
 PROGRAM_VERSION = __VERSION__
 prefix = sys.prefix

--- a/src/updateHandler.py
+++ b/src/updateHandler.py
@@ -236,16 +236,7 @@ def repo_online() -> bool:
     """
     Check if the repository is online.
     """
-    cmd = "pkg -vv | grep -B 1 'enabled.*yes' | grep url"
-    raw_url = Popen(
-        cmd,
-        shell=True,
-        stdout=PIPE,
-        close_fds=True,
-        universal_newlines=True,
-        encoding='utf-8'
-    )
-    server = list(filter(None, raw_url.stdout.read().split('/')))[1]
+    server = list(filter(None, get_default_repo_url().split('/')))[1]
     try:
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.settimeout(5)


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the URL retrieval method in the repo_online function to improve reliability and security by using get_default_repo_url. Update the project version to 5.7 in setup.py.

Bug Fixes:
- Fix the URL retrieval method in the repo_online function to use get_default_repo_url instead of executing a shell command.

Enhancements:
- Update the version number in setup.py from 5.6 to 5.7.

<!-- Generated by sourcery-ai[bot]: end summary -->