### PR TITLE
Adding code to prevent multiple PKGBASE notifications.

### DIFF
--- a/src/update-station
+++ b/src/update-station
@@ -379,7 +379,10 @@ class TrayIcon:
         Function that updates the tray icon.
         """
         if find_if_os_generic_exists():
-            UpgradeToPKGBase()
+            # Simple code avoid showing the Upgrade to PKGBase Window twice.
+            if Data.pkgbase_upgrade_shown is False:
+                Data.pkgbase_upgrade_shown = True
+                UpgradeToPKGBase()
         elif check_for_update():
             GLib.idle_add(self.status_icon.set_visible, True)
             notifier = UpdateNotifier()

--- a/src/update_data.py
+++ b/src/update_data.py
@@ -16,6 +16,7 @@ class Data:
     """
     backup: bool = False
     close_session: bool = False
+    pkgbase_upgrade_shown: bool = False
     current_abi: str = ''
     do_not_upgrade: bool = False
     kernel_upgrade: bool = False


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a new boolean flag 'pkgbase_upgrade_shown' to the Data class to prevent multiple PKGBASE notifications.

New Features:
- Introduce a flag to track whether a PKGBASE upgrade notification has been shown.

<!-- Generated by sourcery-ai[bot]: end summary -->