### PR TITLE
Replaced `hide()` with `destroy()`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from DistUtilsExtra.command.clean_i18n import clean_i18n
 # to update i18n .mo files (and merge .pot file into .po files) run on Linux:
 # python setup.py build_i18n -m''
 
-__VERSION__ = '6.3'
+__VERSION__ = '6.8'
 
 PROGRAM_VERSION = __VERSION__
 prefix = sys.prefix
@@ -21,8 +21,7 @@ def data_file_list(install_base, source_base):
     data = []
     for root, subFolders, files in os.walk(source_base):
         file_list = []
-        for f in files:
-            file_list.append(os.path.join(root, f))
+        file_list.extend(os.path.join(root, f) for f in files)
         data.append((root.replace(source_base, install_base), file_list))
     return data
 

--- a/update_station/frontend.py
+++ b/update_station/frontend.py
@@ -48,13 +48,13 @@ class UpdateWindow:
         Function that handles the delete event when the window is closed.
         :param widget: The widget that triggered the delete event.
         """
-        if Data.close_session is True:
+        if Data.close_session:
             if updating():
                 unlock_update_station()
             Gtk.main_quit()
         else:
             self.window.destroy()
-            if Data.update_started is False:
+            if not Data.update_started:
                 Data.stop_pkg_refreshing = False
                 if updating():
                     unlock_update_station()
@@ -67,7 +67,7 @@ class UpdateWindow:
         """
         Data.update_started = True
         InstallUpdate()
-        self.window.hide()
+        self.window.destroy()
 
     def if_backup(self, widget):
         """
@@ -282,7 +282,6 @@ class InstallUpdate:
                 today_str not in be_name and
                 'NR' not in active_status
         )
-
 
     def read_output(self, progress):
         """
@@ -586,4 +585,4 @@ class StartCheckUpdate:
         :param start_window: The start window object.
         """
         start_window()
-        self.win.hide()
+        self.win.destroy()

--- a/update_station/notification.py
+++ b/update_station/notification.py
@@ -161,4 +161,4 @@ class MajorUpgradeWindow(Gtk.Window):
         else:
             Data.major_upgrade = False
             Data.do_not_upgrade = True
-        self.hide()
+        self.destroy()


### PR DESCRIPTION
Updated conditionals for readability and bumped a version to 6.8 in setup.py.

## Summary by Sourcery

Replace window hiding with destruction and update supporting code and metadata accordingly.

Bug Fixes:
- Ensure update station windows and notifications are fully destroyed instead of merely hidden when closing or completing actions.

Enhancements:
- Simplify boolean conditionals for readability in the frontend logic.
- Refine setup data file collection using list extension with a generator expression and remove an extraneous blank line in frontend code.

Build:
- Bump application version from 6.3 to 6.8 in setup.py.