### PR TITLE
Add boot environment based major version upgrade support

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,17 @@
+# Pylint configuration for GhostBSD python Code
+
+[MASTER]
+# Add current directory to Python path so pylint can find local modules
+init-hook='import sys; sys.path.append(".")'
+
+# Ignore virtual environments and cache directories
+ignore=.venv,venv,.git,__pycache__
+
+[MESSAGES CONTROL]
+disable=import-outside-toplevel,
+    # gi.require_version() must be called between import gi and from gi.repository
+    wrong-import-position
+
+[FORMAT]
+# Maximum line length
+max-line-length=120

--- a/update-station
+++ b/update-station
@@ -26,6 +26,8 @@ from update_station.backend import (
     is_major_upgrade_available,
     get_abi_upgrade,
     get_current_abi,
+    get_current_version,
+    get_version,
 )
 
 gettext.bindtextdomain('update-station', '/usr/local/share/locale')
@@ -103,6 +105,8 @@ def update_tray():
         Data.major_upgrade = True
         Data.current_abi = get_current_abi()
         Data.new_abi = get_abi_upgrade()
+        Data.current_version = get_current_version()
+        Data.new_version = get_version(Data.new_abi)
         Data.system_tray.tray_icon().set_visible(True)
         notifier = UpdateNotifier()
         notifier.notify()

--- a/update_station/backend.py
+++ b/update_station/backend.py
@@ -2,6 +2,7 @@
 """All functions to handle various command for Update Station."""
 
 import os
+import re
 import sys
 import socket
 import requests
@@ -103,7 +104,8 @@ def get_default_repo_url() -> str:
         universal_newlines=True,
         encoding='utf-8'
     )
-    return raw_url.stdout.read().strip().split('"')[1]
+    match = re.search(r'"(https://pkg\.[^"]+/latest)"', raw_url.stdout.read())
+    return match[1]
 
 
 def get_default_base_repo_url(abi: str = '') -> str:
@@ -123,7 +125,8 @@ def get_default_base_repo_url(abi: str = '') -> str:
         universal_newlines=True,
         encoding='utf-8'
     )
-    return raw_url.stdout.read().strip().split('"')[1]
+    match = re.search(r'"(https://pkg\.[^"]+/base)"', raw_url.stdout.read())
+    return match[1]
 
 
 def get_abi_upgrade() -> str:

--- a/update_station/backend.py
+++ b/update_station/backend.py
@@ -175,7 +175,7 @@ def get_version(new_abi: str) -> str:
 
     :return: The full version string (e.g., "25.02-R14.3p8").
     """
-    result = run_command(f'env ABI={new_abi} pkg rquery "%v" GhostBSD-runtime')
+    result = run_command(f'env ABI={new_abi} IGNORE_OSVERSION=yes pkg rquery "%v" GhostBSD-runtime')
     return result.stdout.strip()
 
 

--- a/update_station/backend.py
+++ b/update_station/backend.py
@@ -5,6 +5,8 @@ import os
 import sys
 import socket
 import requests
+import bectl
+import datetime
 from gi.repository import Gtk
 from update_station.data import Data
 from subprocess import Popen, PIPE, call, run, CompletedProcess
@@ -90,11 +92,31 @@ def check_for_update() -> bool:
 def get_default_repo_url() -> str:
     """
     Get the default pkg repository url.
-    
+
     :return: The default pkg repository url.
     """
     raw_url = Popen(
         'pkg -vv | grep -B 1 "enabled.*yes" | grep url | grep latest',
+        shell=True,
+        stdout=PIPE,
+        close_fds=True,
+        universal_newlines=True,
+        encoding='utf-8'
+    )
+    return raw_url.stdout.read().strip().split('"')[1]
+
+
+def get_default_base_repo_url(abi: str = '') -> str:
+    """
+    Get the base repository URL, optionally for a specific ABI.
+
+    :param abi: Optional ABI string (e.g., "FreeBSD:15:amd64"). If empty, uses current ABI.
+
+    :return: The base repository URL (GhostBSD-base repository).
+    """
+    env = f'env ABI={abi} ' if abi else ''
+    raw_url = Popen(
+        f'{env}pkg -vv | grep -B 1 "enabled.*yes" | grep url | grep base',
         shell=True,
         stdout=PIPE,
         close_fds=True,
@@ -121,7 +143,7 @@ def get_abi_upgrade() -> str:
 def get_current_abi() -> str:
     """
     Get the current ABI of the system.
-    
+
     :return: The current ABI of the system.
     """
     pkg_abi = Popen(
@@ -133,6 +155,202 @@ def get_current_abi() -> str:
         encoding='utf-8'
     )
     return pkg_abi.stdout.read().strip()
+
+
+def get_current_version() -> str:
+    """
+    Get the full GhostBSD version currently installed on the system.
+
+    :return: The full version string (e.g., "25.02-R14.3p8").
+    """
+    result = run_command('ghostbsd-version')
+    return result.stdout.strip()
+
+
+def get_version(new_abi: str) -> str:
+    """
+    Get the full GhostBSD version from the new ABI repository.
+
+    :param new_abi: The new ABI string (e.g., "FreeBSD:15:amd64").
+
+    :return: The full version string (e.g., "25.02-R14.3p8").
+    """
+    result = run_command(f'env ABI={new_abi} pkg rquery "%v" GhostBSD-runtime')
+    return result.stdout.strip()
+
+
+def fetch_base_packagelist(new_abi: str) -> list:
+    """
+    Fetch the base package list from the repository.
+
+    :param new_abi: The new ABI string (e.g., "FreeBSD:15:amd64").
+
+    :return: List of base package names.
+    """
+    base_repo_url = get_default_base_repo_url(new_abi)
+    url = f'{base_repo_url}/packagelist.json'
+    response = requests.get(url, timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def cleanup_old_backups(keep_count: int = 5) -> None:
+    """
+    Clean old auto_backup BEs, keeping only the most recent ones by timestamp.
+
+    :param keep_count: Number of auto_backup BEs to keep.
+    """
+    be_list = bectl.get_be_list()
+    auto_backups = [be for be in be_list if 'auto_backup' in be]
+
+    if len(auto_backups) <= keep_count:
+        return
+
+    # Sort by timestamp in BE name (format: version-auto_backup-YYYY-MM-DD_HHmmss)
+    # Extract timestamp after 'auto_backup-' and sort by it (newest first)
+    auto_backups.sort(key=lambda be: be.split()[0].split('auto_backup-')[-1], reverse=True)
+    backups_to_delete = auto_backups[keep_count:]
+
+    for be_line in backups_to_delete:
+        columns = be_line.split()
+        if len(columns) < 4:
+            continue
+        be_name = columns[0]
+        active_status = columns[1]
+        mount_point = columns[2]
+        if 'N' in active_status and mount_point == '/':
+            continue
+        if 'R' in active_status:
+            continue
+        bectl.destroy_be(be_name)
+
+
+def create_be(full_version: str, upgrade: bool = False) -> str:
+    """
+    Create a boot environment.
+
+    :param full_version: The complete version string (e.g., "25.02-R14.3p8").
+    :param upgrade: If True, creates a boot environment for a major upgrade.
+
+    :return: The boot environment name.
+    """
+    timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H%M%S")
+    backup = '' if upgrade else '-auto_backup'
+    be_name = f'{full_version}{backup}-{timestamp}'
+    bectl.create_be(new_be_name=be_name)
+    return be_name
+
+
+def mount_be(be_name: str) -> str:
+    """
+    Mount the boot environment.
+
+    :param be_name: The boot environment name.
+
+    :return: The mount path of the boot environment.
+    """
+    return bectl.mount_be(be_name)
+
+
+def bootstrap_pkg_in_be(mount_path: str, new_abi: str) -> Popen:
+    """
+    Bootstrap pkg in the mounted boot environment.
+
+    :param mount_path: The mount path of the boot environment.
+    :param new_abi: The new ABI string (e.g., "FreeBSD:15:amd64").
+
+    :return: The Popen process object for live output streaming.
+    """
+    command = f'env ABI={new_abi} IGNORE_OSVERSION=yes ASSUME_ALWAYS_YES=yes pkg-static -r {mount_path} bootstrap -f'
+    return command_output(command)
+
+
+def fetch_base_packages_in_be(mount_path: str, new_abi: str, package_list: list) -> Popen:
+    """
+    Fetch base packages in the mounted boot environment.
+
+    :param mount_path: The mount path of the boot environment.
+    :param new_abi: The new ABI string (e.g., "FreeBSD:15:amd64").
+    :param package_list: List of base package names to fetch.
+
+    :return: The Popen process object for live output streaming.
+    """
+    env = f'env ABI={new_abi} ' if new_abi else ''
+    packages = ' '.join(package_list)
+    command = f'{env}pkg-static -r {mount_path} upgrade -Fy {packages}'
+    return command_output(command)
+
+
+def fetch_software_packages_in_be(mount_path: str, new_abi: str = '') -> Popen:
+    """
+    Fetch all remaining software packages in the mounted boot environment.
+
+    :param mount_path: The mount path of the boot environment.
+    :param new_abi: Optional new ABI string (e.g., "FreeBSD:15:amd64"). If empty, uses current ABI.
+
+    :return: The Popen process object for live output streaming.
+    """
+    env = f'env ABI={new_abi} ' if new_abi else ''
+    command = f'{env}pkg-static -r {mount_path} upgrade -Fy'
+    return command_output(command)
+
+
+def upgrade_base_packages_in_be(mount_path: str, new_abi: str, package_list: list) -> Popen:
+    """
+    Install base packages in the mounted boot environment.
+
+    :param mount_path: The mount path of the boot environment.
+    :param new_abi: The new ABI string (e.g., "FreeBSD:15:amd64").
+    :param package_list: List of base package names to upgrade.
+
+    :return: The Popen process object for live output streaming.
+    """
+    env = f'env ABI={new_abi} ' if new_abi else ''
+    packages = ' '.join(package_list)
+    command = f'{env}pkg-static -r {mount_path} upgrade -y {packages}'
+    return command_output(command)
+
+
+def upgrade_software_packages_in_be(mount_path: str, new_abi: str = '') -> Popen:
+    """
+    Install all remaining software packages in the mounted boot environment.
+
+    :param mount_path: The mount path of the boot environment.
+    :param new_abi: Optional new ABI string (e.g., "FreeBSD:15:amd64"). If empty, uses current ABI.
+
+    :return: The Popen process object for live output streaming.
+    """
+    env = f'env ABI={new_abi} ' if new_abi else ''
+    command = f'{env}pkg-static -r {mount_path} upgrade -y'
+    return command_output(command)
+
+
+def umount_upgrade_be(be_name: str) -> None:
+    """
+    Unmount the boot environment.
+
+    :param be_name: The boot environment name.
+    """
+    bectl.umount_be(be_name)
+
+
+def activate_upgrade_be(be_name: str) -> None:
+    """
+    Activate the boot environment for next boot.
+
+    :param be_name: The boot environment name.
+    """
+    bectl.activate_be(be_name)
+
+
+def cleanup_failed_upgrade_be(be_name: str) -> None:
+    """
+    Clean up a failed boot environment upgrade.
+
+    :param be_name: The boot environment name.
+    """
+    bectl.umount_be(be_name)
+    bectl.destroy_be(be_name)
 
 
 def get_pkg_upgrade(option: str = '') -> str:

--- a/update_station/data.py
+++ b/update_station/data.py
@@ -11,12 +11,14 @@ class Data:
         be_name: String that contains the name of the backup boot environment.
         close_session: Boolean that indicates if the update-station should close the session.
         current_abi: String that indicates the current ABI of the system.
+        current_version: String that indicates the current version of the system.
         do_not_upgrade: Boolean that indicates if the update-station should not upgrade the system.
         home: String that indicates the home directory of the user that is running the update-station.
         kernel_upgrade: Boolean that indicates if the update-station should upgrade the kernel.
         packages_dictionary: Dictionary that contains all the packages that are installed on the system.
         major_upgrade: Boolean that indicates if the update-station should do a major upgrade.
         new_abi: String that indicates the new ABI of the system.
+        new_version: String that indicates the new version of the system.
         second_update: Boolean that indicates if the update-station should do 2 update.
         stop_pkg_refreshing: Boolean that indicates if the update-station should stop refreshing the packages.
         system_tray: Object that contains the system tray of the update-station.
@@ -28,11 +30,13 @@ class Data:
     be_mount_path: str = ''
     close_session: bool = False
     current_abi: str = ''
+    current_version: str = ''
     do_not_upgrade: bool = False
     home: str = os.path.expanduser('~')
     kernel_upgrade: bool = False
     major_upgrade: bool = False
     new_abi: str = ''
+    new_version: str = ''
     packages_dictionary: dict = {}
     second_update: bool = False
     stop_pkg_refreshing: bool = False

--- a/update_station/data.py
+++ b/update_station/data.py
@@ -8,6 +8,7 @@ class Data:
 
     Attributes:
         backup: Boolean that indicates if the update-station should back up the current boot environment.
+        be_name: String that contains the name of the backup boot environment.
         close_session: Boolean that indicates if the update-station should close the session.
         current_abi: String that indicates the current ABI of the system.
         do_not_upgrade: Boolean that indicates if the update-station should not upgrade the system.
@@ -23,6 +24,8 @@ class Data:
         username: String that indicates the username of the user that is running the update-station.
     """
     backup: bool = False
+    be_name: str = ''
+    be_mount_path: str = ''
     close_session: bool = False
     current_abi: str = ''
     do_not_upgrade: bool = False

--- a/update_station/dialog.py
+++ b/update_station/dialog.py
@@ -1,5 +1,3 @@
-#!/usr/local/bin/python
-
 import gi
 import gettext
 gi.require_version('Gtk', '3.0')

--- a/update_station/frontend.py
+++ b/update_station/frontend.py
@@ -1,13 +1,17 @@
-import bectl
-import datetime
-import distro
+"""Frontend module for Update Station GTK3 user interface."""
+
 import gettext
 import json
 import re
 import sys
 import threading
-from gi.repository import Gtk, GLib, Notify
 from time import sleep
+
+import bectl
+import gi
+gi.require_version('Gtk', '3.0')
+gi.require_version('Notify', '0.7')
+from gi.repository import Gtk, GLib, Notify
 from update_station.data import Data
 from update_station.dialog import FailedUpdate
 from update_station.dialog import (
@@ -31,7 +35,21 @@ from update_station.backend import (
     command_output,
     is_major_upgrade_available,
     get_current_abi,
-    get_abi_upgrade
+    get_abi_upgrade,
+    get_current_version,
+    get_version,
+    fetch_base_packagelist,
+    cleanup_old_backups,
+    create_be,
+    mount_be,
+    bootstrap_pkg_in_be,
+    cleanup_failed_upgrade_be,
+    fetch_base_packages_in_be,
+    fetch_software_packages_in_be,
+    upgrade_base_packages_in_be,
+    upgrade_software_packages_in_be,
+    umount_upgrade_be,
+    activate_upgrade_be
 )
 
 gettext.bindtextdomain('update-station', '/usr/local/share/locale')
@@ -77,16 +95,18 @@ class UpdateWindow:
                     unlock_update_station()
                 Data.system_tray.tray_icon().set_visible(True)
 
-    def start_update(self, widget):
+    def start_update(self, _widget):
         """
         Function that starts the update process.
-        :param widget: The widget that triggered the start update event.
+
+        :param _widget: The widget that triggered the start update event.
         """
         Data.update_started = True
         InstallUpdate()
         self.window.destroy()
 
-    def if_backup(self, widget):
+    @classmethod
+    def if_backup(cls, widget):
         """
         Function that handles the backup checkbox.
         :param widget: The widget that triggered the checkbox event.
@@ -180,10 +200,6 @@ class UpdateWindow:
         :return: The store for the list of package to be updated.
         """
         self.tree_store.clear()
-        r_num = 0
-        u_num = 0
-        i_num = 0
-        ri_num = 0
         if Data.packages_dictionary['upgrade']:
             message = _('Installed packages to be upgraded:')
             message += f' {Data.packages_dictionary["number_to_upgrade"]}'
@@ -235,7 +251,13 @@ class InstallUpdate:
     """
     The class for the window that is displayed the progress of the update.
     """
-    def close_application(self, widget):
+    @classmethod
+    def close_application(cls, _widget):
+        """
+        Close the application when the window is closed.
+
+        :param _widget: The widget that triggered the close event.
+        """
         if updating():
             unlock_update_station()
         Gtk.main_quit()
@@ -265,40 +287,8 @@ class InstallUpdate:
         # self.pbar.set_size_request(-1, 20)
         vbox2.pack_start(self.pbar, False, False, 0)
         self.win.show_all()
-        self.thr = threading.Thread(target=self.read_output, args=[self.pbar], daemon=True)
+        self.thr = threading.Thread(target=self.process_upgrade, args=[self.pbar], daemon=True)
         self.thr.start()
-
-    @classmethod
-    def should_destroy_be(cls, be_line: str, today_str: str) -> bool:
-        """
-        Determines if a Boot Environment should be destroyed based on criteria.
-        Returns False if the BE is protected (active and mounted at root).
-        :param be_line: The BE line to check.
-        :param today_str:  The string representation of today's date.
-        :return: True if the BE should be destroyed, False otherwise.
-        """
-        # Split the line into columns, handling multiple spaces
-        columns = be_line.split()
-        if len(columns) < 4:
-            return False
-
-        be_name = columns[0]
-        active_status = columns[1]
-        mount_point = columns[2]
-
-        # Protect BE if it's active (N) AND mounted at root (/)
-        if 'N' in active_status and mount_point == '/':
-            return False
-
-        if 'R' in active_status:
-            return False
-
-        # Apply your original deletion criteria
-        return (
-                'backup' in be_name and
-                today_str not in be_name and
-                'NR' not in active_status
-        )
 
     @classmethod
     def log_failure(cls, text: str) -> None:
@@ -307,8 +297,29 @@ class InstallUpdate:
 
         :param text: The failure text to write.
         """
-        with open(f'{Data.home}/update.failed', 'w') as f:
+        with open(f'{Data.home}/update.failed', 'w', encoding='utf-8') as f:
             f.writelines(text)
+
+    @classmethod
+    def process_popen(cls, proc, progress: Gtk.ProgressBar, fraction: float) -> tuple:
+        """
+        Read Popen stdout line by line, updating the progress bar.
+
+        :param proc: The Popen process object.
+        :param progress: The progress bar.
+        :param fraction: The fraction to increment the progress bar.
+        :return: A tuple of (returncode, stdout_text, stderr_text).
+        """
+        stdout_text = ""
+        while True:
+            line = proc.stdout.readline()
+            if not line:
+                break
+            stdout_text += line
+            GLib.idle_add(update_progress, progress, fraction, line.strip())
+        proc.wait()
+        stderr_text = proc.stderr.read()
+        return proc.returncode, stdout_text, stderr_text
 
     @classmethod
     def process_output(
@@ -323,16 +334,7 @@ class InstallUpdate:
         :return: A tuple of (returncode, stdout_text, stderr_text).
         """
         proc = command_output(command)
-        stdout_text = ""
-        while True:
-            line = proc.stdout.readline()
-            if not line:
-                break
-            stdout_text += line
-            GLib.idle_add(update_progress, progress, fraction, line.strip())
-        proc.wait()
-        stderr_text = proc.stderr.read()
-        return proc.returncode, stdout_text, stderr_text
+        return cls.process_popen(proc, progress, fraction)
 
     @classmethod
     def needs_reboot(cls) -> bool:
@@ -341,7 +343,7 @@ class InstallUpdate:
 
         :return: True if a reboot is needed, False otherwise.
         """
-        with open(f'{lib_path}/need_reboot.json') as f:
+        with open(f'{lib_path}/need_reboot.json', encoding='utf-8') as f:
             need_reboot_packages = set(json.loads(f.read()))
         upgrade_packages = set(re.split(": | ", " ".join(Data.packages_dictionary['upgrade'])))
         return bool(need_reboot_packages.intersection(upgrade_packages))
@@ -360,11 +362,10 @@ class InstallUpdate:
         Data.second_update = False
         return False, ''
 
-    def install_packages(self, env: str, option: str, packages: str, progress: Gtk.ProgressBar, fraction: float) -> bool:
+    def install_packages(self, option: str, packages: str, progress: Gtk.ProgressBar, fraction: float) -> bool:
         """
         Install package updates with retry logic for temporary file failures.
 
-        :param env: The ABI environment prefix.
         :param option: The upgrade option flag.
         :param packages: The package names to install.
         :param progress: The progress bar.
@@ -379,20 +380,20 @@ class InstallUpdate:
         sleep(1)
         packages_to_reinstall = []
         max_retries = 5
-        for retry in range(max_retries):
+        for _retry in range(max_retries):
             return_code, install_text, stderr_text = self.process_output(
-                f'{env}pkg-static upgrade -y{option}{packages}',
+                f'pkg-static upgrade -y{option}{packages}',
                 progress, fraction
             )
             if return_code == 3 and 'Fail to create temporary file' in stderr_text:
                 raw_line = install_text.splitlines()[-2]
                 failed_package = raw_line.split()[2].replace(':', '')
                 rquery = command_output(
-                    f'{env}pkg-static rquery -x "%n" "{failed_package}"'
+                    f'pkg-static rquery -x "%n" "{failed_package}"'
                 )
                 package_name = rquery.stdout.read().strip()
                 return_code, delete_text, stderr_text = self.process_output(
-                    f'{env}pkg-static delete -y {package_name}',
+                    f'pkg-static delete -y {package_name}',
                     progress, fraction
                 )
                 if return_code != 0:
@@ -419,7 +420,7 @@ class InstallUpdate:
             progress_message = _("Reinstalling") + f" {package_name}"
             GLib.idle_add(update_progress, progress, fraction, progress_message)
             return_code, reinstall_text, stderr_text = self.process_output(
-                f'{env}pkg-static install -y {package_name}',
+                f'pkg-static install -y {package_name}',
                 progress, fraction
             )
             if return_code != 0:
@@ -427,11 +428,10 @@ class InstallUpdate:
                 return False
         return return_code == 0
 
-    def fetch_packages(self, env: str, option: str, packages: str, progress: Gtk.ProgressBar, fraction: float) -> bool:
+    def fetch_packages(self, option: str, packages: str, progress: Gtk.ProgressBar, fraction: float) -> bool:
         """
         Fetch package updates.
 
-        :param env: The ABI environment prefix.
         :param option: The upgrade option flag.
         :param packages: The package names to fetch.
         :param progress: The progress bar.
@@ -442,7 +442,7 @@ class InstallUpdate:
         GLib.idle_add(update_progress, progress, fraction, progress_message)
         sleep(1)
         return_code, stdout_text, stderr_text = self.process_output(
-            f'{env}pkg-static upgrade -Fy{option}{packages}',
+            f'pkg-static upgrade -Fy{option}{packages}',
             progress, fraction
         )
         if return_code != 0:
@@ -450,69 +450,160 @@ class InstallUpdate:
             return False
         return True
 
-    def bootstrap_major_upgrade(self, env: str, progress: Gtk.ProgressBar, fraction: float) -> bool:
+    def run_upgrade_step(self, proc, progress: Gtk.ProgressBar, fraction: float) -> bool:
         """
-        Bootstrap pkg for a major version upgrade.
+        Run a major upgrade step, logging failure output.
 
-        :param env: The ABI environment prefix.
+        :param proc: The Popen process object.
+        :param progress: The progress bar.
+        :param fraction: The fraction to increment the progress bar.
+        :return: True if step succeeded, False otherwise.
+        """
+        return_code, stdout_text, stderr_text = self.process_popen(proc, progress, fraction)
+        if return_code != 0:
+            self.log_failure(stdout_text + stderr_text)
+            return False
+        return True
+
+    def bootstrap_major_upgrade(self, progress: Gtk.ProgressBar, fraction: float) -> bool:
+        """
+        Bootstrap pkg in the upgrade boot environment.
+
         :param progress: The progress bar.
         :param fraction: The fraction to increment the progress bar.
         :return: True if bootstrap succeeded, False otherwise.
         """
-        progress_message = _("Fetching package updates")
+        progress_message = _("Bootstrapping pkg in new boot environment")
         GLib.idle_add(update_progress, progress, fraction, progress_message)
-        return_code, stdout_text, stderr_text = self.process_output(
-            f'{env}env IGNORE_OSVERSION=yes ASSUME_ALWAYS_YES=yes pkg bootstrap -f',
-            progress, fraction
-        )
-        if return_code != 0:
-            self.log_failure(stdout_text + stderr_text)
-            return False
-        return True
+        proc = bootstrap_pkg_in_be(Data.be_mount_path, Data.new_abi)
+        return self.run_upgrade_step(proc, progress, fraction)
 
-    def prepare_backup(self, progress: Gtk.ProgressBar, fraction: float) -> None:
+    def fetch_major_upgrade(self, base_package_list: list, progress: Gtk.ProgressBar, fraction: float) -> bool:
         """
-        Clean old boot environments and create a new backup.
+        Fetch base and software packages for a major upgrade in the boot environment.
+
+        :param base_package_list: List of base package names to fetch.
+        :param progress: The progress bar.
+        :param fraction: The fraction to increment the progress bar.
+        :return: True if fetch succeeded, False otherwise.
+        """
+        progress_message = _("Fetching base system packages")
+        GLib.idle_add(update_progress, progress, fraction, progress_message)
+        proc = fetch_base_packages_in_be(Data.be_mount_path, Data.new_abi, base_package_list)
+        if not self.run_upgrade_step(proc, progress, fraction):
+            return False
+        progress_message = _("Fetching software packages")
+        GLib.idle_add(update_progress, progress, fraction, progress_message)
+        proc = fetch_software_packages_in_be(Data.be_mount_path, Data.new_abi)
+        return self.run_upgrade_step(proc, progress, fraction)
+
+    def install_major_upgrade(self, base_package_list: list, progress: Gtk.ProgressBar, fraction: float) -> bool:
+        """
+        Install base and software packages for a major upgrade in the boot environment.
+
+        :param base_package_list: List of base package names to install.
+        :param progress: The progress bar.
+        :param fraction: The fraction to increment the progress bar.
+        :return: True if install succeeded, False otherwise.
+        """
+        progress_message = _("Installing base system packages")
+        GLib.idle_add(update_progress, progress, fraction, progress_message)
+        proc = upgrade_base_packages_in_be(Data.be_mount_path, Data.new_abi, base_package_list)
+        if not self.run_upgrade_step(proc, progress, fraction):
+            return False
+        progress_message = _("Installing software packages")
+        GLib.idle_add(update_progress, progress, fraction, progress_message)
+        proc = upgrade_software_packages_in_be(Data.be_mount_path, Data.new_abi)
+        return self.run_upgrade_step(proc, progress, fraction)
+
+    @classmethod
+    def finalize_major_upgrade(cls, progress: Gtk.ProgressBar, fraction: float) -> None:
+        """
+        Unmount and activate the upgrade boot environment.
 
         :param progress: The progress bar.
         :param fraction: The fraction to increment the progress bar.
         """
-        today = datetime.datetime.now().strftime("%Y-%m-%d")
-        progress_message = _("Cleaning old boot environment")
+        progress_message = _("Unmounting boot environment")
         GLib.idle_add(update_progress, progress, fraction, progress_message)
-        for be in bectl.get_be_list():
-            if self.should_destroy_be(be, today):
-                bectl.destroy_be(be.split()[0])
-        backup_name = datetime.datetime.now().strftime(
-            f"{distro.version()}-backup-%Y-%m-%d-%H-%M"
-        )
-        progress_message = _("Creating boot environment")
-        progress_message += f" {backup_name}"
+        umount_upgrade_be(Data.be_name)
+        progress_message = _("Activating new boot environment")
         GLib.idle_add(update_progress, progress, fraction, progress_message)
-        bectl.create_be(new_be_name=backup_name)
+        activate_upgrade_be(Data.be_name)
         sleep(1)
 
-    def read_output(self, progress):
+    @classmethod
+    def prepare_boot_environment(cls, upgrade: bool, progress: Gtk.ProgressBar, fraction: float) -> None:
         """
-        Function that reads the output of the update to update the progress bar.
+        Clean old boot environments and create a new boot environment.
+
+        :param upgrade: True if major upgrade, False otherwise.
+        :param progress: The progress bar.
+        :param fraction: The fraction to increment the progress bar.
+        """
+        progress_message = _("Cleaning old boot environment")
+        GLib.idle_add(update_progress, progress, fraction, progress_message)
+        cleanup_old_backups()
+        version = get_version(Data.new_abi) if upgrade else get_current_version()
+        Data.be_name = create_be(version, upgrade=upgrade)
+        progress_message = _("Creating boot environment")
+        progress_message += f" {Data.be_name}"
+        GLib.idle_add(update_progress, progress, fraction, progress_message)
+        sleep(1)
+
+    @classmethod
+    def mount_upgrade_be(cls, progress: Gtk.ProgressBar, fraction: float) -> None:
+        """
+        Mount the upgrade boot environment.
+
+        :param progress: The progress bar.
+        :param fraction: The fraction to increment the progress bar.
+        """
+        progress_message = _("Mounting boot environment")
+        GLib.idle_add(update_progress, progress, fraction, progress_message)
+        Data.be_mount_path = mount_be(Data.be_name)
+        sleep(1)
+
+    def process_upgrade(self, progress):
+        """
+        Run the full upgrade process, updating the progress bar.
+
         :param progress: The progress bar.
         """
         fail = False
-        env = f'env ABI={Data.new_abi} ' if Data.major_upgrade else ''
         reboot = self.needs_reboot()
         update_pkg, packages = self.is_pkg_only_update()
         option = 'f' if Data.kernel_upgrade else ''
         howmany = (Data.packages_dictionary['total_of_packages'] * 7) + 45
         fraction = 1.0 / howmany
-        if Data.backup:
-            self.prepare_backup(progress, fraction)
-        if Data.major_upgrade and not self.bootstrap_major_upgrade(env, progress, fraction):
+        if Data.major_upgrade:
+            self.prepare_boot_environment(True, progress, fraction)
+            self.mount_upgrade_be(progress, fraction)
+            if not self.bootstrap_major_upgrade(progress, fraction):
+                cleanup_failed_upgrade_be(Data.be_name)
+                GLib.idle_add(self.win.destroy)
+                GLib.idle_add(self.stop_tread, True, update_pkg, True)
+                return
+            base_package_list = fetch_base_packagelist(Data.new_abi)
+            if not self.fetch_major_upgrade(base_package_list, progress, fraction):
+                cleanup_failed_upgrade_be(Data.be_name)
+                GLib.idle_add(self.win.destroy)
+                GLib.idle_add(self.stop_tread, True, update_pkg, True)
+                return
+            if not self.install_major_upgrade(base_package_list, progress, fraction):
+                cleanup_failed_upgrade_be(Data.be_name)
+                GLib.idle_add(self.win.destroy)
+                GLib.idle_add(self.stop_tread, True, update_pkg, True)
+                return
+            self.finalize_major_upgrade(progress, fraction)
             GLib.idle_add(self.win.destroy)
-            GLib.idle_add(self.stop_tread, True, update_pkg, reboot)
+            GLib.idle_add(self.stop_tread, False, update_pkg, True)
             return
-        if not self.fetch_packages(env, option, packages, progress, fraction):
+        if Data.backup:
+            self.prepare_boot_environment(False, progress, fraction)
+        if not self.fetch_packages(option, packages, progress, fraction):
             fail = True
-        elif not self.install_packages(env, option, packages, progress, fraction):
+        elif not self.install_packages(option, packages, progress, fraction):
             fail = True
         GLib.idle_add(self.win.destroy)
         GLib.idle_add(self.stop_tread, fail, update_pkg, reboot)
@@ -547,10 +638,12 @@ class StartCheckUpdate:
     """
     Class for start check for update window.
     """
-    def close_application(self, widget: Gtk.Widget):
+    @classmethod
+    def close_application(cls, _widget: Gtk.Widget):
         """
         The function to close the window.
-        :param widget: The window widget.
+
+        :param _widget: The window widget.
         """
         if updating():
             unlock_update_station()
@@ -689,7 +782,8 @@ class UpdateNotifier:
         self.notification.add_action('clicked', 'Start Upgrade', self.on_activated)
         self.notification.show()
 
-    def on_activated(self, notification, _action_name):
+    @classmethod
+    def on_activated(cls, notification, _action_name):
         """
         Function that starts the upgrade.
         :param notification: The notification widget.
@@ -709,6 +803,11 @@ class TrayIcon:
     """
 
     def tray_icon(self):
+        """
+        Return the status icon widget.
+
+        :return: The GTK StatusIcon.
+        """
         return self.status_icon
 
     def __init__(self):

--- a/update_station/frontend.py
+++ b/update_station/frontend.py
@@ -728,6 +728,8 @@ class StartCheckUpdate:
                         Data.major_upgrade = True
                         Data.current_abi = get_current_abi()
                         Data.new_abi = get_abi_upgrade()
+                        Data.current_version = get_current_version()
+                        Data.new_version = get_version(Data.new_abi)
                         GLib.idle_add(self.stop_tread, MajorUpgradeWindow)
                     else:
                         GLib.idle_add(self.update_progress, progress,
@@ -884,7 +886,7 @@ class MajorUpgradeWindow(Gtk.Window):
             label=_(
                 "Would you like to upgrade from {current} to {new}?\n\n"
                 "If you select No, the upgrade will be skipped until the next boot."
-            ).format(current=Data.current_abi, new=Data.new_abi)
+            ).format(current=Data.current_version, new=Data.new_version)
         )
         vbox.pack_start(label, True, True, 5)
         hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=5)

--- a/update_station/frontend.py
+++ b/update_station/frontend.py
@@ -142,7 +142,7 @@ class UpdateWindow:
         close_button.set_image(img)
         table.attach(close_button, 3, 4, 0, 1)
         close_button.connect("clicked", self.delete_event)
-        install_button = Gtk.Button(label=_("Install update"))
+        install_button = Gtk.Button(label=_("Install Now"))
         table.attach(install_button, 4, 5, 0, 1)
         install_button.connect("clicked", self.start_update)
         return table

--- a/update_station/frontend.py
+++ b/update_station/frontend.py
@@ -131,7 +131,7 @@ class UpdateWindow:
         backup_checkbox.connect("toggled", self.if_backup)
         if bectl.is_file_system_zfs() and Data.second_update is False:
             backup_checkbox.set_active(True)
-            backup_checkbox.set_sensitive(True)
+            backup_checkbox.set_sensitive(not Data.major_upgrade)
             Data.backup = True
         else:
             backup_checkbox.set_active(False)
@@ -167,7 +167,10 @@ class UpdateWindow:
         vbox1.pack_start(vbox2, True, True, 0)
         vbox2.show()
         # Title
-        title_text = _("Updates available!")
+        if Data.major_upgrade:
+            title_text = _("Upgrade to {}").format(Data.new_version)
+        else:
+            title_text = _("Updates available!")
 
         update_title_label = Gtk.Label(
             label=f"<b><span size='large'>{title_text}</span></b>"

--- a/update_station/frontend.py
+++ b/update_station/frontend.py
@@ -782,13 +782,13 @@ class UpdateNotifier:
         self.notification.add_action('clicked', 'Start Upgrade', self.on_activated)
         self.notification.show()
 
-    @classmethod
-    def on_activated(cls, notification, _action_name):
+    def on_activated(self, notification, _action_name):
         """
         Function that starts the upgrade.
         :param notification: The notification widget.
         :param _action_name: The name of the action.
         """
+        Data.stop_pkg_refreshing = True
         if Data.major_upgrade:
             MajorUpgradeWindow()
         else:


### PR DESCRIPTION
Implement full BE-based upgrade flow for major versionupgrades (ABI changes). The new BE is created, mounted, bootstrapped with pkg, then base and software packages are fetched and installed inside it before activating for next boot. Failed upgrades destroy the BE and leave the running system intact.

- Add backend functions: create_be, mount_be, bootstrap_pkg_in_be, fetch/upgrade_base/software_packages_in_be, umount/activate/ cleanup_failed_upgrade_be, get_current_version, get_version, fetch_base_packagelist, get_default_base_repo_url, cleanup_old_backups
- Add be_name and be_mount_path to Data for shared upgrade state
- Refactor InstallUpdate: split process_output into process_popen + process_output, rename read_output to process_upgrade, add major upgrade step methods
- Remove distro dependency, add explicit gi.require_version() calls
- Add .pylintrc configuration

## Summary by Sourcery

Implement boot-environment-based major version upgrade flow and integrate it into the update UI, while refactoring upgrade orchestration and adding supporting backend utilities.

New Features:
- Support performing major version upgrades inside a newly created boot environment, including bootstrapping pkg, fetching, and installing base and software packages before activation.
- Expose backend helpers to query current and target GhostBSD versions, base repository URLs, and base package lists for upgrades.

Enhancements:
- Refactor upgrade execution to separate process spawning from output processing and to introduce reusable helpers for running multi-step upgrade flows.
- Rework boot environment backup handling to use named auto backup boot environments and centralized cleanup logic.
- Make various UI callbacks classmethods, improve parameter naming, and add small robustness improvements such as explicit UTF-8 file handling.

Build:
- Add a .pylintrc configuration file to standardize linting behavior across the project.