### PR TITLE
Downgrade version from 6.8 to 6.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from DistUtilsExtra.command.clean_i18n import clean_i18n
 # to update i18n .mo files (and merge .pot file into .po files) run on Linux:
 # python setup.py build_i18n -m''
 
-__VERSION__ = '6.8'
+__VERSION__ = '6.4'
 
 PROGRAM_VERSION = __VERSION__
 prefix = sys.prefix


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update packaged version metadata from 6.8 to 6.4 in setup.py.